### PR TITLE
Enhance PHP 8.1 compatibility

### DIFF
--- a/easy-school-registration.php
+++ b/easy-school-registration.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * Plugin Name:     Easy School Registration
  * Plugin URI:      https://easyschoolregistration.com/

--- a/inc/class/esr-log.class.php
+++ b/inc/class/esr-log.class.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 // Exit if accessed directly.
 if (!defined('ABSPATH')) {
@@ -7,20 +8,24 @@ if (!defined('ABSPATH')) {
 
 class ESR_Log {
 
-	public function esr_get_all_logs() {
-		global $wpdb;
+       public function esr_get_all_logs(): array {
+               global $wpdb;
 
-		return $wpdb->get_results("SELECT * FROM {$wpdb->prefix}esr_log");
-	}
+               return (array) $wpdb->get_results(
+                       $wpdb->prepare("SELECT * FROM {$wpdb->prefix}esr_log", [])
+               );
+       }
 
-	public function esr_get_logs_by_subtype($subtype) {
-		global $wpdb;
+       public function esr_get_logs_by_subtype(string $subtype): array {
+               global $wpdb;
 
-		return $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}esr_log WHERE subtype = %s", $subtype));
-	}
+               return (array) $wpdb->get_results(
+                       $wpdb->prepare("SELECT * FROM {$wpdb->prefix}esr_log WHERE subtype = %s", $subtype)
+               );
+       }
 
-	public static function esr_log_message($system, $subtype, $status, $message) {
-		global $wpdb;
+       public static function esr_log_message(string $system, string $subtype, string $status, string $message): void {
+               global $wpdb;
 
 		if (intval(ESR()->settings->esr_get_option('log_enabled', -1)) !== -1) {
 			$wpdb->insert($wpdb->prefix . 'esr_log', [
@@ -34,9 +39,9 @@ class ESR_Log {
 	}
 
 
-	public static function esr_log_esr_message($subtype, $status, $message) {
-		do_action('esr_log_message', 'easy_school_registration', $subtype, $status, $message);
-	}
+       public static function esr_log_esr_message(string $subtype, string $status, string $message): void {
+               do_action('esr_log_message', 'easy_school_registration', $subtype, $status, $message);
+       }
 
 }
 

--- a/inc/models/esr-teacher.php
+++ b/inc/models/esr-teacher.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 // Exit if accessed directly.
 if (!defined('ABSPATH')) {
@@ -11,7 +12,7 @@ class ESR_Teacher {
 	/**
 	 * @codeCoverageIgnore
 	 */
-	public function esr_get_teacher_settings_preferences() {
+       public function esr_get_teacher_settings_preferences(): array {
 		return [
 			'limit_registrations' => [
 				'type' => 'checkbox'
@@ -23,10 +24,12 @@ class ESR_Teacher {
 	/**
 	 * @return array|null|object
 	 */
-	public function get_teachers_data() {
+       public function get_teachers_data(): array {
 		global $wpdb;
 
-		$results = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}esr_teacher_data ORDER BY id");
+               $results = $wpdb->get_results(
+                       $wpdb->prepare("SELECT * FROM {$wpdb->prefix}esr_teacher_data ORDER BY id", [])
+               );
 
 		$teachers = [];
 		if ($results) {
@@ -44,7 +47,7 @@ class ESR_Teacher {
 	 *
 	 * @return object
 	 */
-	public function get_teacher_data($id) {
+       public function get_teacher_data(int $id) {
 		global $wpdb;
 		$result = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}esr_teacher_data WHERE id = %d", [$id]));
 
@@ -56,7 +59,7 @@ class ESR_Teacher {
 	}
 
 
-	public function get_teacher_data_by_user($user_id) {
+       public function get_teacher_data_by_user(int $user_id) {
 		global $wpdb;
 		$result = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}esr_teacher_data WHERE user_id = %d", [$user_id]));
 
@@ -68,7 +71,7 @@ class ESR_Teacher {
 	}
 
 
-	public function get_teacher_name($id) {
+       public function get_teacher_name(int $id): string {
 		$teacher = $this->get_teacher_data($id);
 
 		if ($teacher) {
@@ -89,12 +92,12 @@ class ESR_Teacher {
 	 *
 	 * @return string
 	 */
-	public function get_teachers_names($teacher_first, $teacher_second) {
+       public function get_teachers_names(int $teacher_first, ?int $teacher_second): string {
 		return ($teacher_first ? $this->get_teacher_name($teacher_first) : '') . ($teacher_second ? ($teacher_first && $teacher_second ? ' & ' : '') . $this->get_teacher_name($teacher_second) : '');
 	}
 
 
-	private function esr_prepare_teacher_settings($result) {
+       private function esr_prepare_teacher_settings($result): object {
 		if (isset($result->teacher_settings)) {
 			$settings = $result->teacher_settings;
 			unset($result->teacher_settings);
@@ -106,7 +109,7 @@ class ESR_Teacher {
 	}
 
 
-	public function esr_is_user_teacher($user_id) {
+       public function esr_is_user_teacher(int $user_id): bool {
 		global $wpdb;
 		return intval($wpdb->get_var($wpdb->prepare("SELECT EXISTS (SELECT 1 FROM {$wpdb->prefix}esr_teacher_data WHERE user_id = %d)", [$user_id]))) === 1;
 	}

--- a/inc/models/esr-wave.php
+++ b/inc/models/esr-wave.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 // Exit if accessed directly.
 if (!defined('ABSPATH')) {
@@ -24,9 +25,11 @@ class ESR_Wave {
 	/**
 	 * @return array
 	 */
-	public function get_waves_to_process_ids() {
-		global $wpdb;
-		$results = $wpdb->get_results("SELECT id FROM {$wpdb->prefix}esr_wave_data AS wd WHERE NOT wd.is_passed");
+       public function get_waves_to_process_ids(): array {
+               global $wpdb;
+               $results = $wpdb->get_results(
+                       $wpdb->prepare("SELECT id FROM {$wpdb->prefix}esr_wave_data AS wd WHERE NOT wd.is_passed", [])
+               );
 
 		return $this->get_waves_ids_as_array($results);
 	}
@@ -35,7 +38,7 @@ class ESR_Wave {
 	/**
 	 * @return array
 	 */
-	public function get_all_waves_ids() {
+       public function get_all_waves_ids(): array {
 		return $this->get_waves_ids_as_array($this->get_waves_data());
 	}
 
@@ -45,7 +48,7 @@ class ESR_Wave {
 	 *
 	 * @return object
 	 */
-	public function get_wave_data($wave_id) {
+       public function get_wave_data(int $wave_id) {
 		global $wpdb;
 		return $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}esr_wave_data WHERE id = %s", [$wave_id]));
 	}
@@ -54,9 +57,11 @@ class ESR_Wave {
 	/**
 	 * @return array
 	 */
-	public function get_waves_data($as_array = false) {
-		global $wpdb;
-		$data = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}esr_wave_data ORDER BY id DESC");
+       public function get_waves_data($as_array = false) {
+               global $wpdb;
+               $data = $wpdb->get_results(
+                       $wpdb->prepare("SELECT * FROM {$wpdb->prefix}esr_wave_data ORDER BY id DESC", [])
+               );
 
 		if (!$as_array) {
 			return $data;
@@ -70,9 +75,11 @@ class ESR_Wave {
 	 *
 	 * @return object
 	 */
-	public function esr_get_active_waves_data() {
-		global $wpdb;
-		return $wpdb->get_results("SELECT * FROM {$wpdb->prefix}esr_wave_data WHERE NOT is_passed");
+       public function esr_get_active_waves_data(): array {
+               global $wpdb;
+               return $wpdb->get_results(
+                       $wpdb->prepare("SELECT * FROM {$wpdb->prefix}esr_wave_data WHERE NOT is_passed", [])
+               );
 	}
 
 
@@ -80,7 +87,7 @@ class ESR_Wave {
 	 *
 	 * @return object
 	 */
-	public function esr_get_waves_with_active_registration() {
+       public function esr_get_waves_with_active_registration(): array {
 		global $wpdb;
 		$current_time = current_time('Y-m-d H:i:s');
 		return $wpdb->get_results($wpdb->prepare("SELECT * FROM {$wpdb->prefix}esr_wave_data WHERE registration_from <= %s AND registration_to >= %s AND NOT is_passed", [$current_time, $current_time]));
@@ -92,7 +99,7 @@ class ESR_Wave {
 	 *
 	 * @return bool
 	 */
-	public function is_wave_registration_active($wave_id) {
+       public function is_wave_registration_active(int $wave_id): bool {
 		$data         = $this->get_wave_data($wave_id);
 		$current_time = current_time('Y-m-d H:i:s');
 
@@ -106,7 +113,7 @@ class ESR_Wave {
 	 *
 	 * @return bool
 	 */
-	public function is_wave_registration_closed($wave_id) {
+       public function is_wave_registration_closed(int $wave_id): bool {
 		$data         = $this->get_wave_data($wave_id);
 		$current_time = current_time('Y-m-d H:i:s');
 
@@ -138,7 +145,7 @@ class ESR_Wave {
 	 *
 	 * @return bool
 	 */
-	public function is_wave_registration_not_opened_yet($wave_id) {
+       public function is_wave_registration_not_opened_yet(int $wave_id): bool {
 		$data         = $this->get_wave_data($wave_id);
 		$current_time = current_time('Y-m-d H:i:s');
 
@@ -151,7 +158,7 @@ class ESR_Wave {
 	 *
 	 * @return array
 	 */
-	private function get_waves_ids_as_array($results) {
+       private function get_waves_ids_as_array(array $results): array {
 		$waves = [];
 		foreach ($results as $result) {
 			$waves[$result->id] = $result->id;
@@ -166,7 +173,7 @@ class ESR_Wave {
 	 *
 	 * @return array
 	 */
-	private function get_waves_as_array($results) {
+       private function get_waves_as_array(array $results): array {
 		$waves = [];
 		foreach ($results as $result) {
 			$waves[$result->id] = $result;
@@ -179,13 +186,15 @@ class ESR_Wave {
 	/**
 	 * @return array|null|object
 	 */
-	public function esr_load_tinymce_events() {
+       public function esr_load_tinymce_events(): array {
 		global $wpdb;
 
-		return $wpdb->get_results("SELECT title AS text, id AS value FROM {$wpdb->prefix}esr_wave_data ORDER BY id DESC");
+               return $wpdb->get_results(
+                       $wpdb->prepare("SELECT title AS text, id AS value FROM {$wpdb->prefix}esr_wave_data ORDER BY id DESC", [])
+               );
 	}
 
-	public function esr_can_be_removed($wave_id) {
+       public function esr_can_be_removed(int $wave_id): bool {
 		global $wpdb;
 
 		return intval($wpdb->get_var($wpdb->prepare("SELECT 1 FROM {$wpdb->prefix}esr_wave_data AS w WHERE w.id = %d AND NOT EXISTS (SELECT * FROM {$wpdb->prefix}esr_course_data WHERE wave_id = w.id) AND NOT EXISTS (SELECT * FROM {$wpdb->prefix}esr_user_payment WHERE wave_id = w.id)", intval($wave_id)))) === 1;


### PR DESCRIPTION
## Summary
- declare strict types for main plugin and several classes
- use prepared statements for teacher and wave queries
- add return/parameter type hints to models and logging class

## Testing
- `apt-get update`
- `apt-get install -y php-cli`
- `find . -name "*.php" -print0 | xargs -0 -I {} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_6846d7b2e62c8321a594b09bfc6c155c