### PR TITLE
Fix translation path and headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Changelog
 -------
+3.9.1 - 10.06.2025
+
+- Fix: Correct local translation path
+- Update: Add PHP and WP version headers
+
 3.9.0 - 09.06.2025
 
 - Update: Improve PHP 8.1 compatibility

--- a/easy-school-registration.php
+++ b/easy-school-registration.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
  * Plugin URI:      https://easyschoolregistration.com/
  * Description:     Tools to help you run your school better
  *
- * Version:         3.8.9
+ * Version:         3.9.0
+ * Requires at least: 5.0
+ * Requires PHP:    7.4
  * Tested up to:    5.2.2
  *
  * Author:          Zbyněk Nedoma
@@ -271,13 +273,13 @@ if ( ! class_exists( 'Easy_School_Registration' ) ) {
 
 		private function setup_constants() {
 			define( 'ESR_SLUG', 'esr' );
-			define( 'ESR_VERSION', '3.8.9' );
+                        define( 'ESR_VERSION', '3.9.0' );
 			// Plugin Root File.
 			if ( ! defined( 'ESR_PLUGIN_FILE' ) ) {
 				define( 'ESR_PLUGIN_FILE', __FILE__ );
 			}
 
-			define( 'ESR_PLUGIN_PATH', dirname( __FILE__ ) );
+                        define( 'ESR_PLUGIN_PATH', __DIR__ );
 			define( 'ESR_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 			define( 'ESR_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
@@ -457,7 +459,7 @@ if ( ! class_exists( 'Easy_School_Registration' ) ) {
 
 			$mofile = sprintf( '%1$s-%2$s.mo', 'easy-school-registration', $locale );
 
-			$mofile_local  = trailingslashit( ESR_PLUGIN_URL . 'languages' ) . $mofile;
+                        $mofile_local  = trailingslashit( ESR_PLUGIN_DIR . 'languages' ) . $mofile;
 			$mofile_global = WP_LANG_DIR . '/easy-school-registration/' . $mofile;
 
 			if ( file_exists( $mofile_global ) ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,7 +1,7 @@
 <?php
 
-require dirname(__FILE__) . '/inc/database/esr-database.class.php';
-require dirname(__FILE__) . '/inc/enums/esr-role.enum.php';
+require __DIR__ . '/inc/database/esr-database.class.php';
+require __DIR__ . '/inc/enums/esr-role.enum.php';
 
 if (!defined('WP_UNINSTALL_PLUGIN')) {
 	exit('MEHEHE');


### PR DESCRIPTION
## Summary
- add plugin header requirements
- bump ESR version to 3.9.0
- fix path used for loading translations
- modernize path handling in uninstall script
- document new version in changelog

## Testing
- `php -l easy-school-registration.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ed4c846883219747fc7ef16c106e